### PR TITLE
Fix size migration

### DIFF
--- a/migrations/2023-06-28-222639_sizes/up.sql
+++ b/migrations/2023-06-28-222639_sizes/up.sql
@@ -23,11 +23,11 @@ INSERT INTO
     SIZE (
         id,
         title_es,
-        title_en,
         title_fr,
+        title_en,
         size_type_es,
-        size_type_en,
         size_type_fr,
+        size_type_en,
         category_id
     )
 VALUES (


### PR DESCRIPTION
Size migration had columns size_type_fr and size_type_en twisted 